### PR TITLE
🚀 Packaged for Gyro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
 # Build artifacts
 zig-cache/
 *.log
+
+# Gyro
+deps.zig
+.gyro
+gyro.lock
+zig-out/

--- a/gyro.zzz
+++ b/gyro.zzz
@@ -1,0 +1,18 @@
+pkgs:
+  http:
+    version: 0.1.0
+    description: "HTTP core types for Zig 🦴"
+    license: 0BSD
+    source_url: "https://github.com/ducdetronquito/http"
+    tags:
+      http
+
+    root: src/main.zig
+    files:
+      README.md
+      LICENSE
+      src/*.zig
+      src/headers/*.zig
+      src/uri/*.zig
+      src/uri/LICENSE
+      src/uri/README.md


### PR DESCRIPTION
Currently `gyro publish` is crashing with the following error:

```
λ gyro publish
error: NeedPosixPath
Unable to dump stack trace: FileNotFound
```

Setup:
- Code: this branch
- Gyro (0.3.0) (prebuilt for windows-x86_64)
- Zig (0.8.0) (prebuilt for windows-x86_64)
- Gyro commands are executed on [Cmder](https://cmder.net/)
- Windows Pro (10.0.19042 Build 19042)
